### PR TITLE
removes illegal internal module declarations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Konrad Cerny <konrad.cerny@rocket-internet.de>",
     "Florian Topf <florian.topf@rocket-internet.de>"
   ],
-  "license": "GPL",
+  "license": "GPL-3.0",
   "keywords": [
     "grid",
     "datatable",

--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -1,4 +1,3 @@
-/// <reference path="./../../typings/main.d.ts" />
 'use strict';
 
 import UserService from './usersService';

--- a/demo/app/usersPresentationService.ts
+++ b/demo/app/usersPresentationService.ts
@@ -1,5 +1,11 @@
 'use strict';
 
+import {
+    IDataTableService,
+    IGetAllSortingParameter,
+    ISortingParameter
+} from 'rocketGridDatatable';
+
 import { BasePresentationService } from '../../dist/basePresentationService';
 
 export default class UserPresentationService extends BasePresentationService {
@@ -8,13 +14,13 @@ export default class UserPresentationService extends BasePresentationService {
         'UserService',
     ];
 
-    constructor (paginationLimitPerPage: number, service: rocketGridDatatable.IDataTableService) {
+    constructor (paginationLimitPerPage: number, service: IDataTableService) {
         super(paginationLimitPerPage);
 
         this.service = service;
     }
 
-    public getDefaultSorting (): rocketGridDatatable.IGetAllSortingParameter {
+    public getDefaultSorting (): IGetAllSortingParameter {
         return [
             {
                 column: 'email',

--- a/demo/app/usersService.ts
+++ b/demo/app/usersService.ts
@@ -1,6 +1,12 @@
 'use strict';
 
-export default class UserService implements rocketGridDatatable.IDataTableService {
+import {
+    IDataTableService,
+    IDataTableResponse,
+    IGetAllSortingParameter
+} from 'rocketGridDatatable';
+
+export default class UserService implements IDataTableService {
     static $inject: string[] = [
         '$q',
         '$filter',
@@ -62,12 +68,12 @@ export default class UserService implements rocketGridDatatable.IDataTableServic
     constructor(private $q: ng.IQService, private $filter: ng.IFilterService) {}
 
     public getAll (
-        sorting: rocketGridDatatable.IGetAllSortingParameter,
+        sorting: IGetAllSortingParameter,
         limit: number,
         offset: number,
         search: string,
         additionalQueryParameters: {}
-    ): ng.IPromise<rocketGridDatatable.IDataTableResponse<any>> {
+    ): ng.IPromise<IDataTableResponse<any>> {
         let items: any[] = (search) ? this.$filter('filter')(this.users, search) : this.users;
         let total = items.length;
 
@@ -75,7 +81,7 @@ export default class UserService implements rocketGridDatatable.IDataTableServic
             return items[i + offset];
         });
 
-        let result: rocketGridDatatable.IDataTableResponse<any> = {
+        let result: IDataTableResponse<any> = {
             items: items,
             recordsTotal: total,
             offset: offset,

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -5,6 +5,7 @@
         "outDir": "dist"
     },
     "files": [
+        "../typings/main.d.ts",
         "../src/datatable.d.ts",
         "../dist/basePresentationService.ts",
         "../dist/events.ts",

--- a/dist/basePresentationService.ts
+++ b/dist/basePresentationService.ts
@@ -1,13 +1,21 @@
 const DEFAULT_OFFSET = 0;
 
-export class BasePresentationService implements rocketGridDatatable.IPresentationService {
-    public items: ng.IPromise<rocketGridDatatable.IDataTableResponse<any>>;
-    public service: rocketGridDatatable.IDataTableService;
+import {
+    IPresentationService,
+    IDataTableResponse,
+    IDataTableService,
+    ISortingParameter,
+    IGetAllSortingParameter
+} from 'rocketGridDatatable';
+
+export class BasePresentationService implements IPresentationService {
+    public items: ng.IPromise<IDataTableResponse<any>>;
+    public service: IDataTableService;
 
     private limit: number;
     private offset: number = DEFAULT_OFFSET;
     private search: string;
-    private sorting: rocketGridDatatable.IGetAllSortingParameter = [];
+    private sorting: IGetAllSortingParameter = [];
 
     public constructor (paginationLimitPerPage: number) {
         this.limit = paginationLimitPerPage;
@@ -15,12 +23,12 @@ export class BasePresentationService implements rocketGridDatatable.IPresentatio
     }
 
     public getAll (
-        sorting: rocketGridDatatable.IGetAllSortingParameter,
+        sorting: IGetAllSortingParameter,
         limit: number,
         offset: number,
         search: string,
         additionalQueryParameters: {}
-    ): ng.IPromise<rocketGridDatatable.IDataTableResponse<any>> {
+    ): ng.IPromise<IDataTableResponse<any>> {
         this.setSearch(search);
         this.setSorting(sorting);
         this.setLimit(limit);
@@ -39,26 +47,26 @@ export class BasePresentationService implements rocketGridDatatable.IPresentatio
 
     public addSorting (columnName: string, direction: 'asc' | 'desc'): void {
         this.removeSorting(columnName);
-        let newSorting: rocketGridDatatable.ISortingParameter = {
+        let newSorting: ISortingParameter = {
             column: columnName,
             direction: direction,
         };
 
-        let sorting: rocketGridDatatable.IGetAllSortingParameter = this.getSorting();
+        let sorting: IGetAllSortingParameter = this.getSorting();
         sorting.push(newSorting);
 
         this.setSorting(sorting);
     }
 
     public removeSorting (columnName: string): void {
-        let newSorting = <rocketGridDatatable.IGetAllSortingParameter>this.getSorting().filter(
-            (sortingParam: rocketGridDatatable.ISortingParameter) => sortingParam.column !== columnName
+        let newSorting = <IGetAllSortingParameter>this.getSorting().filter(
+            (sortingParam: ISortingParameter) => sortingParam.column !== columnName
         );
 
         this.setSorting(newSorting);
     }
 
-    public getDefaultSorting (): rocketGridDatatable.IGetAllSortingParameter {
+    public getDefaultSorting (): IGetAllSortingParameter {
         return [];
     }
 
@@ -66,7 +74,7 @@ export class BasePresentationService implements rocketGridDatatable.IPresentatio
         return this.search;
     }
 
-    public getSorting (): rocketGridDatatable.IGetAllSortingParameter {
+    public getSorting (): IGetAllSortingParameter {
         return this.sorting;
     }
 
@@ -82,7 +90,7 @@ export class BasePresentationService implements rocketGridDatatable.IPresentatio
         this.search = search;
     }
 
-    private setSorting (sorting: rocketGridDatatable.IGetAllSortingParameter): void {
+    private setSorting (sorting: IGetAllSortingParameter): void {
         this.sorting = sorting;
     }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "Konrad Cerny <konrad.cerny@rocket-internet.de>",
     "Florian Topf <florian.topf@rocket-internet.de>"
   ],
-  "license": "GPL",
+  "license": "GPL-3.0",
   "bugs": {
     "url": "https://github.com/rocket-internet-berlin/RocketGridDatatable/issues"
   },

--- a/src/datatable.d.ts
+++ b/src/datatable.d.ts
@@ -1,4 +1,5 @@
-declare module rocketGridDatatable {
+declare module 'rocketGridDatatable' {
+
     export interface IDataTableService {
         getAll(
             sort: IGetAllSortingParameter,

--- a/src/datatable.directive.ts
+++ b/src/datatable.directive.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { IDataTableResponse, IPresentationService } from 'rocketGridDatatable'
 import { EVENT_PAGE_CHANGED_DATA_TABLE, EVENT_REFRESH_DATA_TABLE_PREFIX } from '../dist/events';
 import { DataTableSortingHelper } from './datatable.helper';
 
@@ -9,7 +10,7 @@ interface IDataTableScopeContent {
 
     // initial scope
     additionalQueryParameters: {};
-    data: rocketGridDatatable.IDataTableResponse<any>;
+    data: IDataTableResponse<any>;
     serviceName: string;
 
     // search
@@ -32,7 +33,7 @@ interface IDataTableScope extends ng.IScope {
 }
 
 class DataTableDirective implements ng.IDirective {
-    private service: rocketGridDatatable.IPresentationService;
+    private service: IPresentationService;
     private $scope: IDataTableScope;
 
     constructor (
@@ -123,7 +124,7 @@ class DataTableDirective implements ng.IDirective {
             this.hasSearch(scopeContent) ? scopeContent.searchValue : '',
             additionalQueryParameters
         ).then(
-            (payload: rocketGridDatatable.IDataTableResponse<any>) => {
+            (payload: IDataTableResponse<any>) => {
                 scopeContent.data = payload;
                 scopeContent.totalItems = payload.recordsTotal;
             }

--- a/src/datatable.helper.ts
+++ b/src/datatable.helper.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { IPresentationService, ISortingParameter } from 'rocketGridDatatable';
+
 const ASCENDING: 'asc' | 'desc' = 'asc';
 const DESCENDING: 'asc' | 'desc' = 'desc';
 const SORTABLE_CLASS: string = 'sortable';
@@ -13,7 +15,7 @@ const SORTABLE_CLASS_DESCENDING: string = 'sortable-' + DESCENDING;
 export class DataTableSortingHelper {
     constructor (
         protected sortableColumns: ng.IAugmentedJQuery,
-        protected service: rocketGridDatatable.IPresentationService,
+        protected service: IPresentationService,
         protected pageChangeCallback: Function
     ) {}
 
@@ -31,7 +33,7 @@ export class DataTableSortingHelper {
                 this.pageChangeCallback();
             });
 
-            this.service.getSorting().forEach((sortingElement: rocketGridDatatable.ISortingParameter) => {
+            this.service.getSorting().forEach((sortingElement: ISortingParameter) => {
                 if (sortingElement.column === column.data('sort')) {
                     column.addClass(
                         sortingElement.direction === ASCENDING ? SORTABLE_CLASS_ASCENDING : SORTABLE_CLASS_DESCENDING


### PR DESCRIPTION
@rokerkony this is what I have seen today when `tslint` "accidentally" run over the sources. We should not declare an internal (proprietary) module in the `d.ts` file. Instead we can define an external module and use imports where ever it's needed.
The reason is simple: The proprietary module declaration pollutes the gobal namespace with `rocketGridDatatable` property. Even if in this case it is not transformed to js code and only used by the compiler - we should not use internal modules anymore.

I will open an issue to introduce `tslint` directly here.